### PR TITLE
Add CircleGuardBench

### DIFF
--- a/collection/dataset/dataset_for_LLM.md
+++ b/collection/dataset/dataset_for_LLM.md
@@ -7,6 +7,7 @@
 |AIR-bench-2024|[AIRBENCH 2024:A Safety Benchmark Based on Risk Categories from Regulations and Policies](https://arxiv.org/pdf/2407.17436)|
 |Malicious-Educator(Applicationrequired)|[H-CoT: Hijacking the Chain-of-Thought Safety Reasoning Mechanism to Jailbreak Large Reasoning Models, Including OpenAI o1/o3, DeepSeek-R1, and Gemini 2.0 Flash Thinking](https://arxiv.org/html/2502.12893v1)|
 |MITRE|[CYBERSECEVAL3:Advancing the Evaluation of Cyber security Risks and Capabilities in Large Language Models](https://arxiv.org/pdf/2408.01605)|
+|CircleGuardBench|[[repo] CircleGuardBench - A full-fledged benchmark for evaluating protection capabilities of AI models](https://github.com/whitecircle-ai/circle-guard-bench)|
 |Interpreter||
 |Phishing||
 |XSTest|Xstest: A test suite for identifying exaggerated safety behaviours in large language models|


### PR DESCRIPTION
Hi!
I’d be glad if you could take a look at the following work and consider adding it to the relevant sections:

CircleGuardBench – A full-fledged benchmark for evaluating protection capabilities of AI models • Repository: https://github.com/whitecircle-ai/circle-guard-bench • Blog post explaining the methodology: https://huggingface.co/blog/whitecircle-ai/circleguardbench • Hugging Face Leaderboard: https://huggingface.co/spaces/whitecircle-ai/circle-guard-bench • Dataset: https://huggingface.co/datasets/whitecircle-ai/circleguardbench_public